### PR TITLE
FT_VALUES Definition

### DIFF
--- a/BMEcatSharp/Types/Classifications/ClassificationGroupFeatureTemplate.cs
+++ b/BMEcatSharp/Types/Classifications/ClassificationGroupFeatureTemplate.cs
@@ -133,7 +133,8 @@ namespace BMEcatSharp
         /// <br/>
         /// XML-namespace: BMECAT
         /// </summary>
-        [BMEXmlElement("FT_VALUES")]
+        [BMEXmlArray("FT_VALUES")]
+        [BMEXmlArrayItem("FT_VALUE")]
         public List<FeatureValue>? Values { get; set; } = new List<FeatureValue>();
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool ValuesSpecified => Values?.Count > 0;


### PR DESCRIPTION
The parameter object "List<FeatureValue> Values" was defined with the XML attribute [BMEXmlElement("FT_VALUES")] while it should be defined with [BMEXmlElement("FT_VALUES")] and [BMEXmlArrayItem("FT_VALUE")].

This error causes a validation error after serializing an XML to BMEcatDocument and makes it impossible to access the values of this FT_VALUES list inside the CLASSIFICATION_GROUP_FEATURE_TEMPLATE object.