### PR TITLE
Bugfix/17 directly set emails not serialized

### DIFF
--- a/src/BMEcatSharp.Samples.AspNetCore/Startup.cs
+++ b/src/BMEcatSharp.Samples.AspNetCore/Startup.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/BMEcatSharp.Tests/BMEcatSerializationTests.cs
+++ b/src/BMEcatSharp.Tests/BMEcatSerializationTests.cs
@@ -241,4 +241,27 @@ public class BMEcatSerializationTests
         generalPublicKeys2[0].Type.Should().Be("c2");
         generalPublicKeys2[0].Value.Should().Be("c22");
     }
+
+    [Test]
+    public void Ticket17_Directly_set_Emails_property_is_serialized_even_if_not_accessed_before_serialization()
+    {
+        string[] emailAddresses = ["email@example.com", "email.2@example.com"];
+        var address = new Address
+        {
+            Emails = emailAddresses.Select(s => new Email
+            {
+                EmailAddress = s
+            }).ToList()
+        };
+
+        var options = new BMEcatXmlSerializerOptions();
+        var serializerFactory = new BMEcatXmlSerializerFactory(options);
+
+        var serializer = serializerFactory.Create<Address>();
+
+        var serializedContent = serializer.Serialize(address);
+
+        serializedContent.Should().Contain("email@example.com");
+        serializedContent.Should().Contain("email.2@example.com");
+    }
 }

--- a/src/BMEcatSharp.Tests/TestConfig.cs
+++ b/src/BMEcatSharp.Tests/TestConfig.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("OpenTransSharp.Tests")]
+﻿[assembly: InternalsVisibleTo("OpenTransSharp.Tests")]
 
 namespace BMEcatSharp.Tests;
 

--- a/src/BMEcatSharp/Types/Address.cs
+++ b/src/BMEcatSharp/Types/Address.cs
@@ -242,7 +242,6 @@ public class Address
         set
         {
             emails = new Lazy<List<Email>?>(() => value);
-            _ = emails.Value; // trigger value evaluation
             EmailComponent.EmailsToEmailComponents(emails, ref emailComponents);
         }
     }
@@ -259,7 +258,7 @@ public class Address
         get
         {
             // HACK: called just before the payload gets serialized
-            EmailComponent.EmailsToEmailComponents(emails, ref emailComponents);
+            EmailComponent.EmailsToEmailComponentsIfValueIsCreated(emails, ref emailComponents);
 
             if (emailComponents?.Count > 0)
             {

--- a/src/BMEcatSharp/Types/Address.cs
+++ b/src/BMEcatSharp/Types/Address.cs
@@ -242,6 +242,7 @@ public class Address
         set
         {
             emails = new Lazy<List<Email>?>(() => value);
+            _ = emails.Value; // trigger value evaluation
             EmailComponent.EmailsToEmailComponents(emails, ref emailComponents);
         }
     }

--- a/src/BMEcatSharp/Types/BMEBuyerAddress.cs
+++ b/src/BMEcatSharp/Types/BMEBuyerAddress.cs
@@ -282,7 +282,6 @@ public class BMEBuyerAddress
         set
         {
             emails = new Lazy<List<Email>?>(() => value);
-            _ = emails.Value; // trigger value evaluation
             EmailComponent.EmailsToEmailComponents(emails, ref emailComponents);
         }
     }

--- a/src/BMEcatSharp/Types/BMEBuyerAddress.cs
+++ b/src/BMEcatSharp/Types/BMEBuyerAddress.cs
@@ -282,6 +282,7 @@ public class BMEBuyerAddress
         set
         {
             emails = new Lazy<List<Email>?>(() => value);
+            _ = emails.Value; // trigger value evaluation
             EmailComponent.EmailsToEmailComponents(emails, ref emailComponents);
         }
     }

--- a/src/BMEcatSharp/Types/BMEBuyerAddress.cs
+++ b/src/BMEcatSharp/Types/BMEBuyerAddress.cs
@@ -299,7 +299,7 @@ public class BMEBuyerAddress
         get
         {
             // HACK: called just before the payload gets serialized
-            EmailComponent.EmailsToEmailComponents(emails, ref emailComponents);
+            EmailComponent.EmailsToEmailComponentsIfValueIsCreated(emails, ref emailComponents);
 
             if (emailComponents?.Count > 0)
             {

--- a/src/BMEcatSharp/Types/BMESupplierAddress.cs
+++ b/src/BMEcatSharp/Types/BMESupplierAddress.cs
@@ -282,7 +282,6 @@ public class BMESupplierAddress
         set
         {
             emails = new Lazy<List<Email>?>(() => value);
-            _ = emails.Value; // trigger value evaluation
             EmailComponent.EmailsToEmailComponents(emails, ref emailComponents);
         }
     }

--- a/src/BMEcatSharp/Types/BMESupplierAddress.cs
+++ b/src/BMEcatSharp/Types/BMESupplierAddress.cs
@@ -299,7 +299,7 @@ public class BMESupplierAddress
         get
         {
             // HACK: called just before the payload gets serialized
-            EmailComponent.EmailsToEmailComponents(emails, ref emailComponents);
+            EmailComponent.EmailsToEmailComponentsIfValueIsCreated(emails, ref emailComponents);
 
             if (emailComponents?.Count > 0)
             {

--- a/src/BMEcatSharp/Types/BMESupplierAddress.cs
+++ b/src/BMEcatSharp/Types/BMESupplierAddress.cs
@@ -282,6 +282,7 @@ public class BMESupplierAddress
         set
         {
             emails = new Lazy<List<Email>?>(() => value);
+            _ = emails.Value; // trigger value evaluation
             EmailComponent.EmailsToEmailComponents(emails, ref emailComponents);
         }
     }

--- a/src/BMEcatSharp/Types/EmailComponent.cs
+++ b/src/BMEcatSharp/Types/EmailComponent.cs
@@ -6,10 +6,21 @@
 public abstract class EmailComponent
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
+    public static void EmailsToEmailComponentsIfValueIsCreated(Lazy<List<Email>?> emails, ref List<EmailComponent>? emailComponents)
+    {
+        if (!emails.IsValueCreated)
+        {
+            emailComponents = [];
+            return;
+        }
+
+        EmailsToEmailComponents(emails, ref emailComponents);
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static void EmailsToEmailComponents(Lazy<List<Email>?> emails, ref List<EmailComponent>? emailComponents)
     {
-        if (!emails.IsValueCreated ||
-            emails.Value is null)
+        if (emails.Value is null)
         {
             emailComponents = [];
             return;

--- a/src/OpenTransSharp.Tests/Orders/OrderSerializationTests.cs
+++ b/src/OpenTransSharp.Tests/Orders/OrderSerializationTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Net.NetworkInformation;
 
 namespace OpenTransSharp.Tests.Orders;
 
@@ -173,5 +174,28 @@ public class OrderSerializationTests
 
         contactEmail1.EmailAddress.Should().Be("mail@example.com");
         contactEmail1.PublicKeys.Count.Should().Be(2);
+    }
+
+    [Test]
+    public void Ticket17_Directly_set_Address_Emails_property_is_serialized_even_if_not_accessed_before_serialization()
+    {
+        string[] emailAddresses = ["email@example.com", "email.2@example.com"];
+        var address = new Address
+        {
+            Emails = emailAddresses.Select(s => new Email
+            {
+                EmailAddress = s
+            }).ToList()
+        };
+
+        var options = new OpenTransXmlSerializerOptions();
+        var serializerFactory = new OpenTransXmlSerializerFactory(options);
+
+        var serializer = serializerFactory.Create<Address>();
+
+        var serializedContent = serializer.Serialize(address);
+
+        serializedContent.Should().Contain("email@example.com");
+        serializedContent.Should().Contain("email.2@example.com");
     }
 }

--- a/src/OpenTransSharp.Tests/Orders/OrderSerializationTests.cs
+++ b/src/OpenTransSharp.Tests/Orders/OrderSerializationTests.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using System.Net.NetworkInformation;
 
 namespace OpenTransSharp.Tests.Orders;
 

--- a/src/OpenTransSharp/Types/Address.cs
+++ b/src/OpenTransSharp/Types/Address.cs
@@ -254,6 +254,7 @@ public class Address
         set
         {
             emails = new Lazy<List<Email>?>(() => value);
+            _ = emails.Value; // trigger value evaluation
             EmailComponent.EmailsToEmailComponents(emails, ref emailComponents);
         }
     }

--- a/src/OpenTransSharp/Types/Address.cs
+++ b/src/OpenTransSharp/Types/Address.cs
@@ -254,7 +254,6 @@ public class Address
         set
         {
             emails = new Lazy<List<Email>?>(() => value);
-            _ = emails.Value; // trigger value evaluation
             EmailComponent.EmailsToEmailComponents(emails, ref emailComponents);
         }
     }
@@ -271,7 +270,7 @@ public class Address
         get
         {
             // HACK: called just before the payload gets serialized
-            EmailComponent.EmailsToEmailComponents(emails, ref emailComponents);
+            EmailComponent.EmailsToEmailComponentsIfValueIsCreated(emails, ref emailComponents);
 
             if (emailComponents?.Count > 0)
             {


### PR DESCRIPTION
Fix #17 where a directly set `Emails` property on an `Address` (BMEcat and OpenTrans) would not be serialized but skipped.