### PR TITLE
fix: REMARK element should be REMARKS

### DIFF
--- a/src/BMEcatSharp.Tests/BMEcatSerializationTests.cs
+++ b/src/BMEcatSharp.Tests/BMEcatSerializationTests.cs
@@ -269,4 +269,52 @@ public class BMEcatSerializationTests
         serializedContent.Should().Contain("email@example.com");
         serializedContent.Should().Contain("email.2@example.com");
     }
+
+    [Test]
+    public void PR26_RemarksHasRightElementName()
+    {
+        // Arrange
+        var order = testConfig.BMEcats.GetBMEcatNewCatalog();
+
+        var productDetails = new ProductDetails
+        {
+            DescriptionShort =
+            [
+                new MultiLingualString("test" , LanguageCodes.deu)
+            ],
+        };
+
+        order.NewCatalog.Products.Add(new NewCatalogProduct
+        {
+            SupplierPid = new SupplierPid("123", SupplierPidTypeValues.Ean.ToString()),
+            OrderDetails = new ProductOrderDetails(),
+            PriceDetails =
+            [
+                new ProductPriceDetails
+                {
+                    ProductPrices =
+                    [
+                        new ProductPrice()
+                        {
+                            Amount = 1m,
+                            Type = ProductPriceTypeValues.GrosList
+                        }
+                    ]
+                }
+            ],
+
+            Details = productDetails
+        });
+
+        // Act
+        productDetails.Remarks =
+        [
+            new MultiLingualString("Product Details DE", LanguageCodes.deu),
+            new MultiLingualString("Product Details EN", LanguageCodes.eng)
+        ];
+
+        // Assert
+        var validationResult = order.Validate(target);
+        validationResult.IsValid.Should().Be(true);
+    }
 }

--- a/src/BMEcatSharp/Types/ProductDetails.cs
+++ b/src/BMEcatSharp/Types/ProductDetails.cs
@@ -217,7 +217,7 @@ public class ProductDetails
     /// <br/>
     /// XML-namespace: BMECAT
     /// </summary>
-    [BMEXmlElement("REMARK")]
+    [BMEXmlElement("REMARKS")]
     public List<MultiLingualString>? Remarks { get; set; } = [];
     [EditorBrowsable(EditorBrowsableState.Never)]
     public bool RemarksSpecified => Remarks?.Count > 0;


### PR DESCRIPTION
According to the bmecat2005 documentation and XSD, the element BMECAT/T_NEW_CATALOG/PRODUCT/REMARK should be named REMARKS 